### PR TITLE
Add OCI image data types and serialization info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,10 @@ dependencies = [
 [[package]]
 name = "eocker"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "eocker-registry"
@@ -710,6 +714,20 @@ name = "serde"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"

--- a/eocker/Cargo.toml
+++ b/eocker/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/eocker/src/digest.rs
+++ b/eocker/src/digest.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Debug)]
+pub struct Hash {
+    pub algorithm: String,
+    pub hex: String,
+}
+
+impl<'de> Deserialize<'de> for Hash {
+    fn deserialize<D>(deserializer: D) -> Result<Hash, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = String::deserialize(deserializer)?;
+        let mut sp = s.split(":");
+        // TODO(hasheddan): perform more robust checks
+        Ok(Hash {
+            algorithm: sp.next().unwrap().to_string(),
+            hex: sp.next().unwrap().to_string(),
+        })
+    }
+}
+
+impl Serialize for Hash {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(format!("{}:{}", self.algorithm, self.hex).as_str())
+    }
+}
+

--- a/eocker/src/digest.rs
+++ b/eocker/src/digest.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug)]
 pub struct Hash {
@@ -12,11 +12,15 @@ impl<'de> Deserialize<'de> for Hash {
         D: Deserializer<'de>,
     {
         let s: String = String::deserialize(deserializer)?;
-        let mut sp = s.split(":");
-        // TODO(hasheddan): perform more robust checks
+        let sp = s
+            .split_once(":")
+            .ok_or_else(|| Error::custom("could not split digest"))?;
+        let algorithm = sp.0.to_string();
+        let hex = sp.1.to_string();
+        // ... checks for validity of digest segments ...
         Ok(Hash {
-            algorithm: sp.next().unwrap().to_string(),
-            hex: sp.next().unwrap().to_string(),
+            algorithm: algorithm,
+            hex: hex,
         })
     }
 }
@@ -29,4 +33,3 @@ impl Serialize for Hash {
         serializer.serialize_str(format!("{}:{}", self.algorithm, self.hex).as_str())
     }
 }
-

--- a/eocker/src/lib.rs
+++ b/eocker/src/lib.rs
@@ -1,1 +1,48 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use types::MediaType;
+
+pub mod digest;
 pub mod types;
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Manifest {
+    schema_version: i64,
+    media_type: Option<MediaType>,
+    config: Descriptor,
+    layers: Vec<Descriptor>,
+    annotations: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexManifest {
+    schema_version: i64,
+    media_type: Option<MediaType>,
+    manifests: Vec<Descriptor>,
+    annotations: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Descriptor {
+    media_type: MediaType,
+    size: i64,
+    digest: digest::Hash,
+    urls: Option<Vec<String>>,
+    annotations: Option<HashMap<String, String>>,
+    platform: Option<Platform>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Platform {
+    architecture: String,
+    os: String,
+    #[serde(rename = "os.version")]
+    os_version: Option<String>,
+    #[serde(rename = "os.features")]
+    os_features: Option<Vec<String>>,
+    variant: Option<String>,
+    features: Option<Vec<String>>,
+}

--- a/eocker/src/types.rs
+++ b/eocker/src/types.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 pub trait Media {
@@ -6,23 +7,41 @@ pub trait Media {
     fn is_index(&self) -> bool;
 }
 
+#[derive(Serialize, Deserialize, Debug)]
 pub enum MediaType {
+    #[serde(rename = "application/vnd.oci.descriptor.v1+json")]
     OCIContentDescriptor,
+    #[serde(rename = "application/vnd.oci.image.index.v1+json")]
     OCIImageIndex,
+    #[serde(rename = "application/vnd.oci.image.manifest.v1+json")]
     OCIManifestSchema1,
+    #[serde(rename = "application/vnd.oci.image.config.v1+json")]
     OCIConfigJSON,
+    #[serde(rename = "application/vnd.oci.image.layer.v1.tar+gzip")]
     OCILayer,
+    #[serde(rename = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip")]
     OCIRestrictedLayer,
+    #[serde(rename = "application/vnd.oci.image.layer.v1.tar")]
     OCIUncompressedLayer,
+    #[serde(rename = "application/vnd.oci.image.layer.nondistributable.v1.tar")]
     OCIUncompressedRestrictedLayer,
+    #[serde(rename = "application/vnd.docker.distribution.manifest.v1+json")]
     DockerManifestSchema1,
+    #[serde(rename = "application/vnd.docker.distribution.manifest.v1+prettyjws")]
     DockerManifestSchema1Signed,
+    #[serde(rename = "application/vnd.docker.distribution.manifest.v2+json")]
     DockerManifestSchema2,
+    #[serde(rename = "application/vnd.docker.distribution.manifest.list.v2+json")]
     DockerManifestList,
+    #[serde(rename = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip")]
     DockerLayer,
+    #[serde(rename = "application/vnd.docker.container.image.v1+json")]
     DockerConfigJSON,
+    #[serde(rename = "application/vnd.docker.plugin.v1+json")]
     DockerPluginConfig,
+    #[serde(rename = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip")]
     DockerForeignLayer,
+    #[serde(rename = "application/vnd.docker.image.rootfs.diff.tar")]
     DockerUncompressedLayer,
 }
 


### PR DESCRIPTION
Adds data types and information for serialization for `Manifest`, `IndexManifest`, `Descriptor` and the types they depend upon. `Hash` serialization / deserialization is implemented naively and will need more robust parsing.