### PR TITLE
Fix docker layer media type name

### DIFF
--- a/eocker/src/types.rs
+++ b/eocker/src/types.rs
@@ -36,7 +36,7 @@ pub enum MediaType {
     DockerManifestSchema2,
     #[serde(rename = "application/vnd.docker.distribution.manifest.list.v2+json")]
     DockerManifestList,
-    #[serde(rename = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip")]
+    #[serde(rename = "application/vnd.docker.image.rootfs.diff.tar.gzip")]
     DockerLayer,
     #[serde(rename = "application/vnd.docker.container.image.v1+json")]
     DockerConfigJSON,


### PR DESCRIPTION
Fixes the media type name for a docker layer in the MediaType enum.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>