### PR TITLE
Add naive image implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +146,7 @@ dependencies = [
  "rust-crypto",
  "serde",
  "serde_json",
+ "serde_with",
  "tar",
 ]
 
@@ -119,6 +155,7 @@ name = "eocker-registry"
 version = "0.1.0"
 dependencies = [
  "eocker",
+ "serde_json",
  "tokio",
  "urlencoding",
  "warp",
@@ -387,6 +424,12 @@ dependencies = [
  "tracing",
  "want",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -850,6 +893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +966,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad9fdbb69badc8916db738c25efd04f0a65297d26c2f8de4b62e57b8c12bc72"
+dependencies = [
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1569374bd54623ec8bd592cf22ba6e03c0f177ff55fbc8c29a49e296e7adecf"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +1032,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/eocker/Cargo.toml
+++ b/eocker/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_with = { version = "1.9.4", features = ["json"] }
 chrono = { version = "0.4.1", features = ["serde"] }
 tar = "0.4"
 flate2 = "1.0"

--- a/eocker/src/digest.rs
+++ b/eocker/src/digest.rs
@@ -1,6 +1,6 @@
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Hash {
     pub algorithm: String,
     pub hex: String,

--- a/eocker/src/lib.rs
+++ b/eocker/src/lib.rs
@@ -10,7 +10,7 @@ pub mod types;
 #[derive(Debug)]
 pub struct Layer {
     pub content: Vec<u8>,
-    pub diff_id: String,
+    pub diff_id: digest::Hash,
     pub descriptor: Descriptor,
 }
 
@@ -48,7 +48,10 @@ impl Layer {
                 platform: None,
             },
             content: tar_gz,
-            diff_id: u.result_str(),
+            diff_id: digest::Hash {
+                algorithm: "sha256".to_string(),
+                hex: u.result_str(),
+            },
         })
     }
 }

--- a/eocker/src/lib.rs
+++ b/eocker/src/lib.rs
@@ -56,6 +56,7 @@ impl Layer {
     }
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Manifest {
@@ -66,6 +67,7 @@ pub struct Manifest {
     pub annotations: Option<HashMap<String, String>>,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexManifest {
@@ -75,7 +77,8 @@ pub struct IndexManifest {
     pub annotations: Option<HashMap<String, String>>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Descriptor {
     pub media_type: MediaType,
@@ -86,7 +89,8 @@ pub struct Descriptor {
     pub platform: Option<Platform>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Platform {
     pub architecture: String,
     pub os: String,
@@ -98,7 +102,8 @@ pub struct Platform {
     pub features: Option<Vec<String>>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct ConfigFile {
     pub architecture: String,
     pub author: Option<String>,
@@ -108,12 +113,13 @@ pub struct ConfigFile {
     pub history: Option<Vec<History>>,
     pub os: String,
     pub rootfs: RootFS,
-    pub config: Config,
+    pub config: Option<Config>,
     #[serde(rename = "os.version")]
     pub os_version: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct History {
     pub author: Option<String>,
     pub created: Option<chrono::DateTime<chrono::Utc>>,
@@ -129,7 +135,17 @@ pub struct RootFS {
     pub diff_ids: Vec<digest::Hash>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+impl Default for RootFS {
+    fn default() -> Self {
+        RootFS {
+            root_fs_type: "layers".to_string(),
+            diff_ids: vec![],
+        }
+    }
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct HealthConfig {
     pub test: Option<Vec<String>>,
     pub interval: Option<time::Duration>,
@@ -138,7 +154,8 @@ pub struct HealthConfig {
     pub retries: Option<i32>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "PascalCase")]
 pub struct Config {
     pub attach_stderr: Option<bool>,

--- a/eocker/src/types.rs
+++ b/eocker/src/types.rs
@@ -10,7 +10,7 @@ pub trait Media {
     fn is_index(&self) -> bool;
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum MediaType {
     #[serde(rename = "application/vnd.oci.descriptor.v1+json")]
     OCIContentDescriptor,


### PR DESCRIPTION
Adds an image implementation that will build a manifest and config file when passed a single layer. Does not implement much of the functionality that is supported by the OCI image spec, but presumably produces a valid image.

Also adds some derived traits and introduces `serde_with` to skip serializing `Option<>` fields with value `None`.