### PR TITLE
Implement OCI distribution (almost) conformant registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,9 @@ name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cfg-if"
@@ -154,10 +157,15 @@ dependencies = [
 name = "eocker-registry"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "eocker",
- "serde_json",
+ "futures",
+ "hyper",
+ "serde",
  "tokio",
+ "tokio-stream",
  "urlencoding",
+ "uuid",
  "warp",
 ]
 
@@ -1037,9 +1045,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.7.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1068,13 +1076,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1227,6 +1236,15 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.3",
+]
 
 [[package]]
 name = "version_check"

--- a/eocker-registry/Cargo.toml
+++ b/eocker-registry/Cargo.toml
@@ -9,6 +9,12 @@ readme = "README.md"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+bytes = { version = "1", features = ["serde"] }
+hyper = { version = "0.14" }
+tokio-stream = { version = "0.1.7", features = ["sync"] }
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
+uuid = { version = "0.8", features = ["v4"] }
+serde = { version = "1.0", features = ["derive"] }
 warp = "0.3"
 eocker = { path = "../eocker" }
 urlencoding = "2.0.0"

--- a/eocker-registry/src/codes.rs
+++ b/eocker-registry/src/codes.rs
@@ -1,0 +1,17 @@
+// TODO(hasheddan): return error codes as defined in spec
+enum Errors {
+    BlobUnknown,
+    BlobUploadInvalid,
+    BlobUploadUnknown,
+    DigestInvalid,
+    ManifestBlobUnknown,
+    ManifestInvalid,
+    ManifestUnknown,
+    NameInvalid,
+    NameUnknown,
+    SizeInvalid,
+    Unauthorized,
+    Denied,
+    Unsupported,
+    Toomanyrequests,
+}

--- a/eocker-registry/src/filters.rs
+++ b/eocker-registry/src/filters.rs
@@ -1,0 +1,203 @@
+use futures::StreamExt;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+use uuid::Uuid;
+use futures::Stream;
+use warp::Filter;
+
+use super::handlers::{
+    blob_exists, get_blob, get_manifest, manifest_exists, store_blob, store_manifest,
+};
+
+use super::store::{BlobStore, ManifestStore, PushQuery};
+
+fn with_blob_store(
+    store: BlobStore,
+) -> impl Filter<Extract = (BlobStore,), Error = std::convert::Infallible> + Clone {
+    warp::any().map(move || store.clone())
+}
+
+fn with_manifest_store(
+    store: ManifestStore,
+) -> impl Filter<Extract = (ManifestStore,), Error = std::convert::Infallible> + Clone {
+    warp::any().map(move || store.clone())
+}
+
+fn with_tx(
+    tx: broadcast::Sender<String>,
+) -> impl Filter<Extract = (broadcast::Sender<String>,), Error = std::convert::Infallible> + Clone {
+    warp::any().map(move || tx.clone())
+}
+
+fn with_rx(
+    tx: broadcast::Sender<String>,
+) -> impl Filter<Extract = (broadcast::Receiver<String>,), Error = std::convert::Infallible> + Clone
+{
+    warp::any().map(move || tx.subscribe())
+}
+
+pub fn registry(
+    manifests: ManifestStore,
+    blobs: BlobStore,
+    tx: broadcast::Sender<String>,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    events(tx.clone())
+        .or(support(tx))
+        .or(pull_manifest(manifests.clone()))
+        .or(pull_blob(blobs.clone()))
+        .or(check_manifest(manifests.clone()))
+        .or(check_blob(blobs.clone()))
+        .or(blob_location())
+        .or(push_blob_location())
+        .or(push_blob(blobs))
+        .or(push_manifest(manifests))
+}
+
+pub fn events(
+    tx: broadcast::Sender<String>,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path("events")
+        .and(warp::get())
+        .and(with_rx(tx))
+        .map(|rx: broadcast::Receiver<String>| {
+            warp::sse::reply(convert_broadcast(BroadcastStream::new(rx)))
+        })
+}
+
+fn convert_broadcast(s: tokio_stream::wrappers::BroadcastStream<String>) -> impl Stream<Item = Result<warp::sse::Event, warp::Error>> + Send + 'static {
+    // Convert broadcast stream messages into server side events.
+    s.map(|msg| {
+        Ok(warp::sse::Event::default().data(msg.unwrap()))
+    })
+}
+
+// --- Support
+
+// Specification Support
+// GET /v2/
+// Does not currently support authn / authz checks.
+pub fn support(tx: broadcast::Sender<String>) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v2").and(warp::get()).and(with_tx(tx)).map(|tx: broadcast::Sender<String>| {
+        tx.send("support".to_string()).unwrap();
+        warp::reply()
+    })
+}
+
+// --- Pull
+
+// Pull Manifest
+// GET /v2/<name>/manifests/<reference>
+pub fn pull_manifest(
+    store: ManifestStore,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v2" / String / "manifests" / String)
+        .and(warp::get())
+        .and(with_manifest_store(store))
+        .and_then(get_manifest)
+}
+
+// Pull Blob
+// GET /v2/<name>/blobs/<digest>
+pub fn pull_blob(
+    store: BlobStore,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v2" / String / "blobs" / String)
+        .and(warp::get())
+        .and(with_blob_store(store))
+        .and_then(get_blob)
+}
+
+// Check Manifest
+// HEAD /v2/<name>/manifests/<reference>
+pub fn check_manifest(
+    store: ManifestStore,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v2" / String / "manifests" / String)
+        .and(warp::head())
+        .and(with_manifest_store(store))
+        .and_then(manifest_exists)
+}
+
+// Check Blob
+// HEAD /v2/<name>/blobs/<digest>
+pub fn check_blob(
+    store: BlobStore,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v2" / String / "blobs" / String)
+        .and(warp::head())
+        .and(with_blob_store(store))
+        .and_then(blob_exists)
+}
+
+// --- Push
+// Currently only support monolithic POST / PUT
+
+// Blob Location
+// POST /v2/<name>/blobs/uploads
+pub fn blob_location() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v2" / String / "blobs" / "uploads")
+        .and(warp::post())
+        .map(|name: String| {
+            warp::reply::with_header(
+                (|| warp::http::StatusCode::ACCEPTED)(),
+                "Location",
+                format!("/v2/{}/blobs/uploads/{}", name, Uuid::new_v4()),
+            )
+        })
+}
+
+// Push Blob Location
+// Redirects single POST blob upload to PUT.
+// POST /v2/<name>/blobs/uploads/?digest=<digest>
+pub fn push_blob_location(
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v2" / String / "blobs" / "uploads")
+        .and(warp::post())
+        .and(warp::header("Content-Length"))
+        .and(warp::header::exact(
+            "Content-Type",
+            "application/octet-stream",
+        ))
+        .and(warp::query::<PushQuery>())
+        .map(|name: String, _: String, _: PushQuery| {
+            warp::reply::with_header(
+                (|| warp::http::StatusCode::ACCEPTED)(),
+                "Location",
+                format!("/v2/{}/blobs/uploads/{}", name, Uuid::new_v4()),
+            )
+        })
+}
+
+// Push Blob
+// PUT /v2/<name>/blobs/uploads/<uuid>?digest=<digest>
+pub fn push_blob(
+    store: BlobStore,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v2" / String / "blobs" / "uploads" / Uuid)
+        .and(warp::put())
+        .and(warp::header("Content-Length"))
+        .and(warp::header::exact(
+            "Content-Type",
+            "application/octet-stream",
+        ))
+        .and(warp::query::<PushQuery>())
+        .and(warp::body::bytes())
+        .and(with_blob_store(store))
+        .and_then(store_blob)
+}
+
+// Push Manifest
+// PUT /v2/<name>/manifests/<reference>
+pub fn push_manifest(
+    store: ManifestStore,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v2" / String / "manifests" / String)
+        .and(warp::put())
+        .and(warp::header::exact(
+            "Content-Type",
+            "application/vnd.oci.image.manifest.v1+json",
+        ))
+        .and(warp::body::bytes())
+        .and(with_manifest_store(store))
+        .and_then(store_manifest)
+}

--- a/eocker-registry/src/handlers.rs
+++ b/eocker-registry/src/handlers.rs
@@ -1,0 +1,113 @@
+use bytes::Bytes;
+use std::{collections::HashMap, convert::Infallible};
+use uuid::Uuid;
+use warp::http::StatusCode;
+
+use super::store::{BlobStore, Manifest, ManifestStore, PushQuery};
+
+pub async fn store_blob(
+    _: String,
+    _: Uuid,
+    _: String,
+    query: PushQuery,
+    content: Bytes,
+    store: BlobStore,
+) -> Result<impl warp::Reply, Infallible> {
+    // NOTE(hasheddan): blobs are currently stored at global scope
+    let mut s = store.lock().await;
+    s.insert(query.digest, content);
+    Ok(StatusCode::OK)
+}
+
+pub async fn get_blob(
+    _: String,
+    digest: String,
+    store: BlobStore,
+) -> Result<impl warp::Reply, Infallible> {
+    let s = store.lock().await;
+    match s.get(digest.as_str()) {
+        None => Ok(warp::http::Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(bytes::Bytes::new())),
+        Some(b) => Ok(warp::http::Response::builder()
+            .status(StatusCode::OK)
+            .header("Docker-Content-Digest", digest)
+            .header("Content-Length", b.len())
+            .body(b.clone())),
+    }
+}
+
+pub async fn blob_exists(
+    _: String,
+    digest: String,
+    store: BlobStore,
+) -> Result<impl warp::Reply, Infallible> {
+    let s = store.lock().await;
+    if s.contains_key(digest.as_str()) {
+        return Ok(StatusCode::OK);
+    }
+    Ok(StatusCode::NOT_FOUND)
+}
+
+pub async fn store_manifest(
+    repo: String,
+    reference: String,
+    content: Bytes,
+    store: ManifestStore,
+) -> Result<impl warp::Reply, Infallible> {
+    // TODO(hasheddan): consider only locking nested repo manifest hash map
+    let mut s = store.lock().await;
+    let e = s.entry(repo).or_insert_with(|| HashMap::new());
+    e.insert(
+        reference,
+        Manifest {
+            content_type: "application/vnd.oci.image.manifest.v1+json".to_string(),
+            content: content,
+        },
+    );
+    Ok(StatusCode::OK)
+}
+
+pub async fn get_manifest(
+    repo: String,
+    reference: String,
+    store: ManifestStore,
+) -> Result<impl warp::Reply, Infallible> {
+    // TODO(hasheddan): consider only locking nested repo manifest hash map
+    let s = store.lock().await;
+    match s.get(repo.as_str()) {
+        None => Ok(warp::http::Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(bytes::Bytes::new())),
+        Some(r) => match r.get(reference.as_str()) {
+            None => Ok(warp::http::Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(bytes::Bytes::new())),
+            Some(m) => Ok(warp::http::Response::builder()
+                .status(StatusCode::OK)
+                // TODO(hasheddan): set Docker-Content-Digest header
+                .header("Content-Type", m.content_type.clone())
+                .header("Content-Length", m.content.len())
+                .body(m.content.clone())),
+        },
+    }
+}
+
+pub async fn manifest_exists(
+    repo: String,
+    reference: String,
+    store: ManifestStore,
+) -> Result<impl warp::Reply, Infallible> {
+    // TODO(hasheddan): consider only locking nested repo manifest hash map
+    let s = store.lock().await;
+    let e = s.get(repo.as_str());
+    match e {
+        None => Ok(StatusCode::NOT_FOUND),
+        Some(m) => {
+            if m.contains_key(reference.as_str()) {
+                return Ok(StatusCode::OK);
+            }
+            Ok(StatusCode::NOT_FOUND)
+        }
+    }
+}

--- a/eocker-registry/src/store.rs
+++ b/eocker-registry/src/store.rs
@@ -1,0 +1,31 @@
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(Debug, Deserialize)]
+pub struct PushQuery {
+    // TODO(hasheddan): use eocker digest
+    pub digest: String,
+}
+
+// TODO(hasheddan): consider using a RwLock
+pub type BlobStore = Arc<Mutex<HashMap<String, Bytes>>>;
+
+pub fn new_blob_store() -> BlobStore {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Manifest {
+    pub content_type: String,
+    pub content: Bytes,
+}
+
+// TODO(hasheddan): consider using a RwLock
+pub type ManifestStore = Arc<Mutex<HashMap<String, HashMap<String, Manifest>>>>;
+
+pub fn new_manifest_store() -> ManifestStore {
+    Arc::new(Mutex::new(HashMap::new()))
+}


### PR DESCRIPTION
Gets us most of the way towards an OCI distribution conformant registry (see caveats in commits). Also demonstrates sending server side events to clients subscribed to `/events`, currently only implement on the `/v2` endpoint (i.e. distribution version support indicator).