### PR TITLE
Send events on broadcast channel for registry operations

### DIFF
--- a/eocker-registry/src/channel.rs
+++ b/eocker-registry/src/channel.rs
@@ -1,0 +1,22 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tokio::sync::Mutex;
+
+pub type ChannelMap = Arc<Mutex<HashMap<String, broadcast::Sender<String>>>>;
+
+// TODO(hasheddan): channels are not cleaned up when no one is subscribed.
+pub fn new_channel_map() -> ChannelMap {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+pub async fn send(ns: &str, message: String, sm: ChannelMap) {
+    let st = sm.lock().await;
+    match st.get(ns) {
+        // If channel exists we will send on it.
+        None => (),
+        Some(tx) => {
+            tx.send(message).unwrap();
+        }
+    }
+}

--- a/eocker-registry/src/handlers.rs
+++ b/eocker-registry/src/handlers.rs
@@ -1,18 +1,24 @@
 use bytes::{BufMut, Bytes};
+use futures::Stream;
+use futures::StreamExt;
 use std::io::Write;
 use std::{collections::HashMap, convert::Infallible};
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
 use uuid::Uuid;
 use warp::http::StatusCode;
 
+use super::channel::{send, ChannelMap};
 use super::store::{BlobStore, Manifest, ManifestStore, PushQuery, UploadStore};
 
 pub async fn store_chunk(
-    name: String,
+    ns: String,
     id: Uuid,
     _: Option<String>,
     content_range: Option<String>,
     content: Bytes,
     store: BlobStore,
+    cm: ChannelMap,
 ) -> Result<impl warp::Reply, Infallible> {
     // NOTE(hasheddan): chunks are currently stored at global scope
     let start = match content_range {
@@ -56,9 +62,15 @@ pub async fn store_chunk(
                 }
             }
             // Insert first chunk into upload store
+            send(
+                &ns,
+                format!("({}) Upload Chunk | Location:  {}", ns, id),
+                cm,
+            )
+            .await;
             Ok(warp::http::Response::builder()
                 .status(StatusCode::ACCEPTED)
-                .header("Location", format!("/v2/{}/blobs/uploads/{}", name, id))
+                .header("Location", format!("/v2/{}/blobs/uploads/{}", ns, id))
                 .body(bytes::Bytes::new()))
         }
         Some(b) => {
@@ -75,22 +87,29 @@ pub async fn store_chunk(
             buf.write(b).unwrap();
             buf.write(&content).unwrap();
             *b = buf.into_inner().into();
+            send(
+                &ns,
+                format!("({}) Upload Chunk | Location:  {}", ns, id),
+                cm,
+            )
+            .await;
             Ok(warp::http::Response::builder()
                 .status(StatusCode::ACCEPTED)
-                .header("Location", format!("/v2/{}/blobs/uploads/{}", name, id))
+                .header("Location", format!("/v2/{}/blobs/uploads/{}", ns, id))
                 .body(bytes::Bytes::new()))
         }
     }
 }
 
 pub async fn store_blob(
-    _: String,
+    ns: String,
     id: Uuid,
     _: String,
     query: PushQuery,
     content: Bytes,
     blob_store: BlobStore,
     upload_store: UploadStore,
+    cm: ChannelMap,
 ) -> Result<impl warp::Reply, Infallible> {
     // NOTE(hasheddan): blobs and uploads are currently stored at global scope
     let mut s = blob_store.lock().await;
@@ -100,7 +119,7 @@ pub async fn store_blob(
         None => {
             // Upload store does not have a record for id, so we go ahead and
             // store full blob in blob store
-            s.insert(query.digest, content);
+            s.insert(query.digest.clone(), content);
         }
         Some(b) => {
             // Prior upload chunks exist so we append bytes to existing and
@@ -110,21 +129,36 @@ pub async fn store_blob(
             // safely
             buf.write(b).unwrap();
             buf.write(&content).unwrap();
-            s.insert(query.digest, buf.into_inner().into());
+            s.insert(query.digest.clone(), buf.into_inner().into());
             // Blob has been uploaded, chunks can be removed from upload store
             u.remove(id_string.as_str());
         }
     }
-
+    send(
+        &ns,
+        format!(
+            "({}) Upload Blob | Location: {} | Digest: {}",
+            ns, id, query.digest
+        ),
+        cm,
+    )
+    .await;
     Ok(StatusCode::CREATED)
 }
 
 pub async fn get_blob(
-    _: String,
+    ns: String,
     digest: String,
     store: BlobStore,
+    cm: ChannelMap,
 ) -> Result<impl warp::Reply, Infallible> {
     let s = store.lock().await;
+    send(
+        &ns,
+        format!("({}) Download Blob | Digest: {}", ns, digest),
+        cm,
+    )
+    .await;
     match s.get(digest.as_str()) {
         None => Ok(warp::http::Response::builder()
             .status(StatusCode::NOT_FOUND)
@@ -137,46 +171,89 @@ pub async fn get_blob(
     }
 }
 
+fn convert_broadcast(
+    s: tokio_stream::wrappers::BroadcastStream<String>,
+) -> impl Stream<Item = Result<warp::sse::Event, warp::Error>> + Send + 'static {
+    // Convert broadcast stream messages into server side events.
+    s.map(|msg| Ok(warp::sse::Event::default().data(msg.unwrap())))
+}
+
+pub async fn send_events(ns: String, cm: ChannelMap) -> Result<impl warp::Reply, Infallible> {
+    let mut c = cm.lock().await;
+    // Check if channel exists for namespace and create one if it does not.
+    let tx = c.entry(ns).or_insert(broadcast::channel::<String>(10).0);
+    Ok(warp::sse::reply(convert_broadcast(BroadcastStream::new(
+        tx.subscribe(),
+    ))))
+}
+
 pub async fn blob_exists(
-    _: String,
+    ns: String,
     digest: String,
     store: BlobStore,
+    cm: ChannelMap,
 ) -> Result<impl warp::Reply, Infallible> {
     let s = store.lock().await;
     if s.contains_key(digest.as_str()) {
+        send(
+            &ns,
+            format!("({}) Check Blob: EXISTS | Digest: {}", ns, digest),
+            cm,
+        )
+        .await;
         return Ok(StatusCode::OK);
     }
+    send(
+        &ns,
+        format!("({}) Check Blob: MISSING | Digest: {}", ns, digest),
+        cm,
+    )
+    .await;
     Ok(StatusCode::NOT_FOUND)
 }
 
 pub async fn store_manifest(
-    repo: String,
+    ns: String,
     reference: String,
     content_type: String,
     content: Bytes,
     store: ManifestStore,
+    cm: ChannelMap,
 ) -> Result<impl warp::Reply, Infallible> {
     // TODO(hasheddan): consider only locking nested repo manifest hash map
     let mut s = store.lock().await;
-    let e = s.entry(repo).or_insert_with(|| HashMap::new());
+    let e = s.entry(ns.clone()).or_insert_with(|| HashMap::new());
     e.insert(
-        reference,
+        reference.clone(),
         Manifest {
             content_type: content_type,
             content: content,
         },
     );
+    send(
+        &ns,
+        format!("({}) Upload Manifest | Reference: {}", ns, reference),
+        cm,
+    )
+    .await;
     Ok(StatusCode::CREATED)
 }
 
 pub async fn get_manifest(
-    repo: String,
+    ns: String,
     reference: String,
     store: ManifestStore,
+    sm: ChannelMap,
 ) -> Result<impl warp::Reply, Infallible> {
     // TODO(hasheddan): consider only locking nested repo manifest hash map
     let s = store.lock().await;
-    match s.get(repo.as_str()) {
+    send(
+        &ns,
+        format!("({}) Download Manifest | Reference: {}", ns, reference),
+        sm,
+    )
+    .await;
+    match s.get(ns.as_str()) {
         None => Ok(warp::http::Response::builder()
             .status(StatusCode::NOT_FOUND)
             .body(bytes::Bytes::new())),
@@ -195,19 +272,32 @@ pub async fn get_manifest(
 }
 
 pub async fn manifest_exists(
-    repo: String,
+    ns: String,
     reference: String,
     store: ManifestStore,
+    cm: ChannelMap,
 ) -> Result<impl warp::Reply, Infallible> {
     // TODO(hasheddan): consider only locking nested repo manifest hash map
     let s = store.lock().await;
-    let e = s.get(repo.as_str());
+    let e = s.get(ns.as_str());
     match e {
         None => Ok(StatusCode::NOT_FOUND),
         Some(m) => {
             if m.contains_key(reference.as_str()) {
+                send(
+                    &ns,
+                    format!("({}) Check Manifest: EXISTS | Reference: {}", ns, reference),
+                    cm,
+                )
+                .await;
                 return Ok(StatusCode::OK);
             }
+            send(
+                &ns,
+                format!("({}) Check Blob: MISSING | Digest: {}", ns, reference),
+                cm,
+            )
+            .await;
             Ok(StatusCode::NOT_FOUND)
         }
     }

--- a/eocker-registry/src/main.rs
+++ b/eocker-registry/src/main.rs
@@ -1,5 +1,4 @@
-use tokio::sync::broadcast;
-
+mod channel;
 mod codes;
 mod filters;
 mod handlers;
@@ -7,16 +6,16 @@ mod store;
 
 #[tokio::main]
 async fn main() {
-    let (tx, _) = broadcast::channel::<String>(10);
     let blob_store = store::new_blob_store();
     let upload_store = store::new_upload_store();
     let manifest_store = store::new_manifest_store();
+    let channel_map = channel::new_channel_map();
 
     warp::serve(filters::registry(
         manifest_store,
         blob_store,
         upload_store,
-        tx,
+        channel_map,
     ))
     .run(([127, 0, 0, 1], 8080))
     .await;


### PR DESCRIPTION
Adds a `ChannelMap` for maintaining a broadcast channel per namespace. Users subscribed to a namespace will receive events from handlers that perform operations in that namespace.