### PR TITLE
Add basic logging and support Range header for blobs and Docker-Content-Digest for manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "futures",
  "hyper",
  "serde",
+ "sha2",
  "tokio",
  "tokio-stream",
  "urlencoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +161,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "eocker"
 version = "0.1.0"
 dependencies = [
@@ -158,6 +191,7 @@ name = "eocker-registry"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "env_logger",
  "eocker",
  "futures",
  "hyper",
@@ -396,6 +430,12 @@ name = "httpdate"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -814,6 +854,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1073,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1318,6 +1384,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/eocker-registry/Cargo.toml
+++ b/eocker-registry/Cargo.toml
@@ -18,3 +18,4 @@ serde = { version = "1.0", features = ["derive"] }
 warp = "0.3"
 eocker = { path = "../eocker" }
 urlencoding = "2.0.0"
+env_logger = "0.9"

--- a/eocker-registry/Cargo.toml
+++ b/eocker-registry/Cargo.toml
@@ -19,3 +19,4 @@ warp = "0.3"
 eocker = { path = "../eocker" }
 urlencoding = "2.0.0"
 env_logger = "0.9"
+sha2 = "0.9"

--- a/eocker-registry/src/handlers.rs
+++ b/eocker-registry/src/handlers.rs
@@ -43,6 +43,7 @@ pub async fn store_chunk(
     };
     let mut s = store.lock().await;
     let id_string = id.to_string();
+    let content_len = content.len()-1;
     match s.get_mut(id_string.as_str()) {
         None => {
             match start {
@@ -71,6 +72,7 @@ pub async fn store_chunk(
             Ok(warp::http::Response::builder()
                 .status(StatusCode::ACCEPTED)
                 .header("Location", format!("/v2/{}/blobs/uploads/{}", ns, id))
+                .header("Range", format!("0-{}", content_len))
                 .body(bytes::Bytes::new()))
         }
         Some(b) => {

--- a/eocker-registry/src/handlers.rs
+++ b/eocker-registry/src/handlers.rs
@@ -1,13 +1,13 @@
 use bytes::{BufMut, Bytes};
 use futures::Stream;
 use futures::StreamExt;
+use sha2::{Digest, Sha256};
 use std::io::Write;
 use std::{collections::HashMap, convert::Infallible};
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 use uuid::Uuid;
 use warp::http::StatusCode;
-use sha2::{Digest, Sha256};
 
 use super::channel::{send, ChannelMap};
 use super::store::{BlobStore, Manifest, ManifestStore, PushQuery, UploadStore};
@@ -44,7 +44,7 @@ pub async fn store_chunk(
     };
     let mut s = store.lock().await;
     let id_string = id.to_string();
-    let content_len = content.len()-1;
+    let content_len = content.len() - 1;
     match s.get_mut(id_string.as_str()) {
         None => {
             match start {
@@ -242,9 +242,12 @@ pub async fn store_manifest(
     )
     .await;
     Ok(warp::http::Response::builder()
-            .status(StatusCode::CREATED)
-            .header("Docker-Content-Digest", format!("sha256:{:x}", c.finalize()))
-            .body(bytes::Bytes::new()))
+        .status(StatusCode::CREATED)
+        .header(
+            "Docker-Content-Digest",
+            format!("sha256:{:x}", c.finalize()),
+        )
+        .body(bytes::Bytes::new()))
 }
 
 pub async fn get_manifest(

--- a/eocker-registry/src/main.rs
+++ b/eocker-registry/src/main.rs
@@ -1,3 +1,5 @@
+use warp::Filter;
+
 mod channel;
 mod codes;
 mod filters;
@@ -6,17 +8,17 @@ mod store;
 
 #[tokio::main]
 async fn main() {
+    env_logger::init();
+
     let blob_store = store::new_blob_store();
     let upload_store = store::new_upload_store();
     let manifest_store = store::new_manifest_store();
     let channel_map = channel::new_channel_map();
 
-    warp::serve(filters::registry(
-        manifest_store,
-        blob_store,
-        upload_store,
-        channel_map,
-    ))
+    warp::serve(
+        filters::registry(manifest_store, blob_store, upload_store, channel_map)
+            .with(warp::log("eocker")),
+    )
     .run(([127, 0, 0, 1], 8080))
     .await;
 }


### PR DESCRIPTION
These updates are required for the Docker client to be compatible. Tested this out by pushing a Crossplane image:

```
🤖 (eocker) docker push 127.0.0.1:8080/cross:v1.3.0
The push refers to repository [127.0.0.1:8080/cross]
4526d9e6e074: Pushed 
2122fc2f3286: Pushed 
1a5ede0c966b: Pushed 
v1.3.0: digest: sha256:490b278a0b4a20972d6f9a8d1dcbda23e7c498f3e0b5d1de08cc5bfd4517926f size: 928
```

Relevant logs:
```
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37590 "GET /v2/ HTTP/1.1" 200 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 196.975µs
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37594 "HEAD /v2/cross/blobs/sha256:190f5491daad24d383bc6ffa6618f0ca4960cdbcd642d7740fd100c7d3c8a2b9 HTTP/1.1" 404 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 626.514µs
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37598 "HEAD /v2/cross/blobs/sha256:60775238382ed8f096b163a652f5457589739d65f1395241aba12847e7bdc2a1 HTTP/1.1" 404 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 873.612µs
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37592 "HEAD /v2/cross/blobs/sha256:1b48853b1e4ea443181d07acda08ccfa5f97713dd4c87937cb1376f7499e0b68 HTTP/1.1" 404 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 1.558531ms
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37600 "POST /v2/cross/blobs/uploads/ HTTP/1.1" 202 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 586.056µs
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37602 "POST /v2/cross/blobs/uploads/ HTTP/1.1" 202 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 941.334µs
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37604 "POST /v2/cross/blobs/uploads/ HTTP/1.1" 202 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 1.205632ms
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37610 "PATCH /v2/cross/blobs/uploads/81ec0a79-03b2-4dfe-83dd-cd86b146f6f5 HTTP/1.1" 202 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 23.420548ms
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37612 "PUT /v2/cross/blobs/uploads/81ec0a79-03b2-4dfe-83dd-cd86b146f6f5 HTTP/1.1" 201 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 861.985µs
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37614 "HEAD /v2/cross/blobs/sha256:1b48853b1e4ea443181d07acda08ccfa5f97713dd4c87937cb1376f7499e0b68 HTTP/1.1" 200 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 336.749µs
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37608 "PATCH /v2/cross/blobs/uploads/bf5a905a-e00d-4ac8-b461-18f4538f67f7 HTTP/1.1" 202 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 244.943367ms
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37616 "PUT /v2/cross/blobs/uploads/bf5a905a-e00d-4ac8-b461-18f4538f67f7 HTTP/1.1" 201 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 593.448µs
[2021-09-05T20:53:32Z INFO  eocker] 127.0.0.1:37618 "HEAD /v2/cross/blobs/sha256:60775238382ed8f096b163a652f5457589739d65f1395241aba12847e7bdc2a1 HTTP/1.1" 200 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 492.36µs
[2021-09-05T20:53:33Z INFO  eocker] 127.0.0.1:37606 "PATCH /v2/cross/blobs/uploads/c931d994-67de-4ee2-bb54-eeb1719dd920 HTTP/1.1" 202 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 1.553098095s
[2021-09-05T20:53:34Z INFO  eocker] 127.0.0.1:37620 "PUT /v2/cross/blobs/uploads/c931d994-67de-4ee2-bb54-eeb1719dd920 HTTP/1.1" 201 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 6.32278ms
[2021-09-05T20:53:34Z INFO  eocker] 127.0.0.1:37622 "HEAD /v2/cross/blobs/sha256:190f5491daad24d383bc6ffa6618f0ca4960cdbcd642d7740fd100c7d3c8a2b9 HTTP/1.1" 200 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 148.034µs
[2021-09-05T20:53:34Z INFO  eocker] 127.0.0.1:37624 "HEAD /v2/cross/blobs/sha256:48eeff1ca1f672d6c8f01c5eecebf2f5a2aa485a19a19a68cbfc05b4f16a7bd8 HTTP/1.1" 404 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 136.133µs
[2021-09-05T20:53:34Z INFO  eocker] 127.0.0.1:37626 "POST /v2/cross/blobs/uploads/ HTTP/1.1" 202 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 170.913µs
[2021-09-05T20:53:34Z INFO  eocker] 127.0.0.1:37628 "PATCH /v2/cross/blobs/uploads/31c833d3-eb8b-474d-b94f-82a122a5c575 HTTP/1.1" 202 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 278.1µs
[2021-09-05T20:53:34Z INFO  eocker] 127.0.0.1:37630 "PUT /v2/cross/blobs/uploads/31c833d3-eb8b-474d-b94f-82a122a5c575 HTTP/1.1" 201 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 281.734µs
[2021-09-05T20:53:34Z INFO  eocker] 127.0.0.1:37632 "HEAD /v2/cross/blobs/sha256:48eeff1ca1f672d6c8f01c5eecebf2f5a2aa485a19a19a68cbfc05b4f16a7bd8 HTTP/1.1" 200 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 123.524µs
[2021-09-05T20:53:34Z INFO  eocker] 127.0.0.1:37634 "PUT /v2/cross/manifests/v1.3.0 HTTP/1.1" 201 "-" "docker/20.10.6 go/go1.13.15 git-commit/8728dd2 kernel/5.4.0-81-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.6 \(linux\))" 487.902µs

```