### PR TITLE
Handle manifest lists correctly and support sending object references

### DIFF
--- a/eocker-registry/Cargo.toml
+++ b/eocker-registry/Cargo.toml
@@ -20,3 +20,4 @@ eocker = { path = "../eocker" }
 urlencoding = "2.0.0"
 env_logger = "0.9"
 sha2 = "0.9"
+serde_json = "1.0"

--- a/eocker-registry/src/channel.rs
+++ b/eocker-registry/src/channel.rs
@@ -18,6 +18,7 @@ pub async fn send(
     method: Method,
     status: StatusCode,
     identifier: String,
+    refs: Option<Vec<Ref>>,
     sm: ChannelMap,
 ) {
     let st = sm.lock().await;
@@ -31,6 +32,7 @@ pub async fn send(
                 status: status.as_str().to_string(),
                 repo: ns.to_string(),
                 identifier: identifier,
+                objects: refs,
             })
             .unwrap();
         }
@@ -46,4 +48,13 @@ pub struct Event {
     status: String,
     repo: String,
     identifier: String,
+    objects: Option<Vec<Ref>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Ref {
+    pub data_type: String,
+    pub repo: String,
+    pub identifier: String,
 }

--- a/eocker-registry/static/index.html
+++ b/eocker-registry/static/index.html
@@ -67,10 +67,10 @@ function renderManifests(state) {
   return renderNodes(state, "Manifest");
 }
 
-function renderNodes(state, kind) {
+function renderNodes(state, dataType) {
   let objs = [];
   for (let obj of state.objects) {
-    if (obj.dataType == kind) {
+    if (obj.dataType == dataType) {
       let s = `"${obj.identifier}"`;
       if (obj.color) {
         s += ` [color="${obj.color}", penwidth=2]`;
@@ -91,20 +91,19 @@ function renderEdges(state) {
   for (let edge of state.edges) {
     let src = edge.src;
     let dst = edge.dst;
-
-    if (src.Kind = "Upload") {
+    if (src.dataType == "Blob") {
       src = edge.dst;
       dst = edge.src;
     }
 
-    let s = `"${src.Identifier}" -> "${dst.Identifier}"`;
+    let s = `"${src.identifier}" -> "${dst.identifier}"`;
     if (edge.color) {
-      if (src.Kind = "Upload") {
+      if (src.dataType == "Upload") {
         s += ` [color="${edge.color}", dir=back]`;
       } else {
         s += ` [color="${edge.color}"]`;
       }
-    } else if (src.Kind = "Upload") {
+    } else if (src.dataType == "Upload") {
         s += ` [dir=back]`;
     }
 
@@ -124,14 +123,13 @@ var colors = {
 };
 
 function match(obj, e) {
-  return obj.kind == e.kind && obj.identifier == e.identifier && obj.repo == e.repo;
+  return obj.dataType == e.dataType && obj.identifier == e.identifier && obj.repo == e.repo;
 }
 
 // (state, event) => state
 function updateState(state, e) {
   let nodeFound = false;
 
-  // console.log(e);
   if (!e.objects) {
     e.objects = [];
   }
@@ -160,10 +158,10 @@ function updateState(state, e) {
   outer:
   for (let i = 0; i < state.edges.length; i++) {
     let edge = state.edges[i];
-    for (let j = 0; j < e.Objects.length; j++) {
-      if (match(edge.dst, e.Objects[j])) {
-        edge.color = colors[e.Status] || "black";
-        e.Objects.splice(j, 1);
+    for (let j = 0; j < e.objects.length; j++) {
+      if (match(edge.dst, e.objects[j])) {
+        edge.color = colors[e.status] || "black";
+        e.objects.splice(j, 1);
         continue outer;
       }
     }
@@ -184,7 +182,7 @@ function updateState(state, e) {
       repo: e.repo,
       color: colors[e.status] || "black"
     }
-    if (e.status == 404 || (e.kind == "Upload" && e.method == "PATCH")) {
+    if (e.status == 404 || (e.dataType == "Upload" && e.method == "PATCH")) {
       obj.temporary = true;
     }
     
@@ -207,18 +205,18 @@ function updateState(state, e) {
   for (let target of e.objects) {
     let edge = {
       src: {
-        kind: e.kind,
+        dataType: e.dataType,
         identifier: e.identifier,
         repo: e.repo
       },
       dst: {
-        kind: target.kind,
+        dataType: target.dataType,
         identifier: target.identifier,
         repo: target.repo
       },
       color: colors[e.status] || "black"
     };
-    if (e.kind = "Upload") {
+    if (e.dataType == "Blob") {
       edge.temporary = true;
     }
     state.edges.push(edge);
@@ -247,7 +245,6 @@ function appendEvent(dataType, identifier, method, status) {
 let eventSource = new EventSource("/events/cross");
 
 eventSource.onmessage = function(event) {
-  console.log("New message", event.data);
   json = JSON.parse(event.data)
   updateState(currentState, json);
   dots.push(renderState(currentState));


### PR DESCRIPTION
Updates to handle a manifest list being pushed as a manifest, and adds support for sending object references (such as manifests to blobs) on SSE channels.